### PR TITLE
Fix comment holder width on discussion timeline

### DIFF
--- a/wide-github.js
+++ b/wide-github.js
@@ -33,6 +33,9 @@ if (document.getElementById('js-repo-pjax-container')) {
       "margin-right:160px;" +
       "width:auto !important;" +
     "}" +
+    ".repository-content .comment-holder {" +
+      "max-width:none !important;" +
+    "}" +
     ".repository-content #repo-settings {" +
       "margin-right:235px;" +
     "}" +


### PR DESCRIPTION
This fixes the comment blocks in a discussion timeline which do not stretch to the full width of the `.discussion-timeline` container.
