### PR TITLE
Bug: side bar not reacting to hover/click events when in a pull request page

### DIFF
--- a/wide-github.user.js
+++ b/wide-github.user.js
@@ -57,6 +57,7 @@
         "margin-left:-160px;" +
         "padding-left:160px;" +
         "width:100% !important;" +
+        "z-index:-1 !important;" +
       "}" +
       ".repository-content .timeline-new-comment {" + // New Issue / issue comment form
         "max-width:100% !important;" +


### PR DESCRIPTION
Bug: When going to a pull request page, then trying to selecting a label/assignee from the right side-bar, the links are not reacting to hover/click events. This occurs due to the fact that the padding-right for `.repository-content .discussion-timeline` makes it overlay on top of `.discussion-sidebar`. Hence, events are not passing through to `.discussion-sidebar`. The quick fix for that is to change the z-index of `.repository-content .discussion-timeline` to something less (in this case, -1) so that the `.discussion-sidebar` becomes on top.

Other specs:
```
Chromium	41.0.2272.76 (Developer Build) Ubuntu 14.04
Revision	ff3293b421463d090f04f4d942d64af8cfd3b234
OS	Linux 
Blink	537.36 (@191030)
JavaScript	V8 4.1.0.21
Flash	14.0.0.177
User Agent	Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/41.0.2272.76 Chrome/41.0.2272.76 Safari/537.36
Command Line	/usr/lib/chromium-browser/chromium-browser --ppapi-flash-path=/usr/lib/pepperflashplugin-nonfree/libpepflashplayer.so --ppapi-flash-version=14.0.0.177 --enable-pinch --flag-switches-begin --enable-devtools-experiments --flag-switches-end
```

OS: Ubuntu 14.04 LTS , Using Chromium version in the ubuntu repositories (chrome stable).