### PR TITLE
Limit width for inline comments

### DIFF
--- a/wide-github.css
+++ b/wide-github.css
@@ -54,13 +54,13 @@
   max-width:100% !important;
 }
 .repository-content .inline-comments .comment-holder { /* Diff / code comments */
-  max-width:none !important;
+  max-width:920px !important;
 }
 .repository-content .inline-comments .inline-comment-form-container {
-  max-width:none !important;
+  max-width:920px !important;
 }
 .repository-content .inline-comments .inline-comment-form {
-  max-width:none !important;
+  max-width:920px !important;
 }
 
 /* Repository pulse page */


### PR DESCRIPTION
https://github.com/xthexder/wide-github/issues/17

I know it's not ideal since comments will be limited to 920px but I can't think how to make it based on screen width without getting javascript involved.

after the fix:
![selection_221](https://cloud.githubusercontent.com/assets/321391/15015728/7fbdb5c2-1205-11e6-80d8-424ee7ed2a15.png)
