### PR TITLE
Change to not apply on github settings page

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,6 +11,7 @@
   "content_scripts": [
     {
       "matches": ["https://github.com/*", "https://gist.github.com/*"],
+      "exclude_matches": ["https://github.com/settings/*"],
       "css": ["wide-github.css"]
     }
   ],


### PR DESCRIPTION
Applying css on settings page will mess up the barcode for two-
factor authentication. There is no need to make page wide for
settings.