### PR TITLE
Update wide-github.css

### DIFF
--- a/wide-github.css
+++ b/wide-github.css
@@ -1,4 +1,5 @@
-.header .container {
+.header .container,
+.header .container-lg {
   width: auto !important;
   margin-left: 20px !important;
   margin-right: 20px !important;


### PR DESCRIPTION
It looks like Github changed the selector for the navbar in the last 24 hours, this update reflects that.