### PR TITLE
Header change

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Wide Github",
   "description": "Change all Github repository and gist pages to be full width and dynamically sized.",
-  "version": "1.2.0",
+  "version": "1.2.1",
 
   "browser_action": {
     "default_icon": "icon.png"

--- a/wide-github.css
+++ b/wide-github.css
@@ -1,4 +1,5 @@
-.header .container {
+.header .container,
+.header .container-lg {
   width: auto !important;
   margin-left: 20px !important;
   margin-right: 20px !important;

--- a/wide-github.css
+++ b/wide-github.css
@@ -1,5 +1,5 @@
-.header .container,
-.header .container-lg {
+header .container,
+header .container-lg {
   width: auto !important;
   margin-left: 20px !important;
   margin-right: 20px !important;

--- a/wide-github.user.js
+++ b/wide-github.user.js
@@ -18,7 +18,8 @@
 // ==/UserScript==
 
 var styleSheet = "" +
-".header .container {" +
+".header .container," +
+".header .container-lg {" +
   "width: auto !important;" +
   "margin-left: 20px !important;" +
   "margin-right: 20px !important;" +

--- a/wide-github.user.js
+++ b/wide-github.user.js
@@ -9,7 +9,7 @@
 // @contributor Jason Frey (https://github.com/Fryguy)
 // @contributor Marti Martz (https://github.com/Martii)
 // @license     MIT License; https://raw.githubusercontent.com/xthexder/wide-github/master/LICENSE
-// @version     1.2.0
+// @version     1.2.1
 // @icon        https://raw.githubusercontent.com/xthexder/wide-github/master/icon.png
 // @homepageURL https://github.com/xthexder/wide-github
 // @supportURL  https://github.com/xthexder/wide-github/issues

--- a/wide-github.user.js
+++ b/wide-github.user.js
@@ -24,6 +24,7 @@ var styleSheet = "" +
   "margin-left: 20px !important;" +
   "margin-right: 20px !important;" +
   "min-width: 980px;" +
+  "max-width: initial;" +
 "}" +
 "#js-repo-pjax-container .container {" +
   "width: auto !important;" +

--- a/wide-github.user.js
+++ b/wide-github.user.js
@@ -18,8 +18,8 @@
 // ==/UserScript==
 
 var styleSheet = "" +
-".header .container," +
-".header .container-lg {" +
+"header .container," +
+"header .container-lg {" +
   "width: auto !important;" +
   "margin-left: 20px !important;" +
   "margin-right: 20px !important;" +


### PR DESCRIPTION
Github recently changed their header class from `.header` to `.Header`. That prevented the script from making the header wide.

In this PR I change the selector to match the `header` element (thinking that is less likely to change), so the header now becomes wide again.

I included brandon's `.container-lg` fix in the history.

I also bumped the version number to `1.2.1`, for convenience.