### PR TITLE
Fix to SPDX

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,7 @@
   ],
   "licenses": [
     {
-      "type": "MIT License",
+      "type": "MIT",
       "url": "https://raw.githubusercontent.com/xthexder/wide-github/master/LICENSE"
     }
   ]

--- a/wide-github.user.js
+++ b/wide-github.user.js
@@ -8,7 +8,7 @@
 // @copyright   2013+, xthexder (https://github.com/xthexder)
 // @contributor Jason Frey (https://github.com/Fryguy)
 // @contributor Marti Martz (https://github.com/Martii)
-// @license     MIT License; https://raw.githubusercontent.com/xthexder/wide-github/master/LICENSE
+// @license     MIT; https://raw.githubusercontent.com/xthexder/wide-github/master/LICENSE
 // @version     1.2.0
 // @icon        https://raw.githubusercontent.com/xthexder/wide-github/master/icon.png
 // @homepageURL https://github.com/xthexder/wide-github


### PR DESCRIPTION
OUJS has made a change recently to require SPDX codes for OSI approved licensing.

In order to improve the appearance of your script homepages it would be appreciated if you could modify this affected script.

Until this change is made you will be unable to update this script.

Thanks for your support.
OUJS Staff