### PR TITLE
Fix for discussion timeline on profile pages

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Wide Github",
   "description": "Change all Github repository and gist pages to be full width and dynamically sized.",
-  "version": "1.2.2",
+  "version": "1.2.3",
 
   "browser_action": {
     "default_icon": "icon.png"

--- a/wide-github.css
+++ b/wide-github.css
@@ -25,7 +25,7 @@ header .container-lg {
   padding-left: 220px;
   width: 100% !important;
 }
-.discussion-timeline::before { /* The vertical line running through the commit list on PRs */
+#js-repo-pjax-container .repository-content .discussion-timeline::before { /* The vertical line running through the commit list on PRs and issues */
   margin-left: 220px;
 }
 .repository-content .discussion-sidebar {

--- a/wide-github.user.js
+++ b/wide-github.user.js
@@ -10,7 +10,7 @@
 // @contributor Marti Martz (https://github.com/Martii)
 // @contributor Paul "Joey" Clark (https://github.com/joeytwiddle)
 // @license     MIT; https://raw.githubusercontent.com/xthexder/wide-github/master/LICENSE
-// @version     1.2.2
+// @version     1.2.3
 // @icon        https://raw.githubusercontent.com/xthexder/wide-github/master/icon.png
 // @homepageURL https://github.com/xthexder/wide-github
 // @supportURL  https://github.com/xthexder/wide-github/issues
@@ -46,7 +46,7 @@ var styleSheet = "" +
   "padding-left: 220px;" +
   "width: 100% !important;" +
 "}" +
-".discussion-timeline::before {" + // The vertical line running through the commit list on PRs
+"#js-repo-pjax-container .repository-content .discussion-timeline::before {" + // The vertical line running through the commit list on PRs and issues
   "margin-left: 220px;" +
 "}" +
 ".repository-content .discussion-sidebar {" +


### PR DESCRIPTION
I have noticed that my previous PR #32 introduced a bug.

Whilst it fixed the vertical timeline line on PR and issue pages, it broke the line on profile pages!

![joey s google-chrome at 1 10 36 pm on sunday 17 june 2018](https://user-images.githubusercontent.com/911799/41504976-c1da9924-7230-11e8-9ce1-66dec94b4883.png)

Obviously I should have used the same selector as the one I was fixing (which only activates on PR/issue pages). I have now done this.