### PR TITLE
Add a Stylus build routine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 
-all: js chrome
+all: js css chrome
+
+css:
+	node makecss.js
 
 js:
-	node make.js
+	node makejs.js
 
 chrome:
 	zip wide-github.zip LICENSE manifest.json wide-github.css icon.png
@@ -12,3 +15,4 @@ clean:
 
 clean-all: clean
 	rm -f wide-github.user.js
+	rm -f wide-github.user.css

--- a/README.md
+++ b/README.md
@@ -16,7 +16,11 @@ As a Greasemonkey / UserScript:
 
 This script can be installed into Greasemonkey or other user script plugins by going here: [wide-github.user.js](https://raw.githubusercontent.com/xthexder/wide-github/master/wide-github.user.js)
 
+As a Stylus / UserCSS
+
+This style can be installed into Stylus by going here: [wide-github.user.css](https://raw.githubusercontent.com/xthexder/wide-github/master/wide-github.user.css)
+
 Development
 -----------
 
-To generate the user.js file for Greasemonkey, run `make js`. The chrome extension can be built using `make chrome`.
+To generate the user.js for Greasemonkey, run `make js`. The user.css can be built using `make css`. The chrome extension can be built using `make chrome`.

--- a/makecss.js
+++ b/makecss.js
@@ -1,0 +1,41 @@
+"use strict";
+
+var fs = require('fs');
+
+var manifest = JSON.parse(fs.readFileSync('manifest.json'));
+
+var header = "" +
+"/* ==UserStyle==\n" +
+"@name         " + manifest["name"] + "\n" +
+"@namespace    https://github.com/xthexder/wide-github\n" +
+"@description  " + manifest["description"] + "\n" +
+"@author       xthexder\n" +
+"@copyright    2013+, xthexder (https://github.com/xthexder)\n" +
+"@contributor  Jason Frey (https://github.com/Fryguy)\n" +
+"@contributor  Marti Martz (https://github.com/Martii)\n" +
+"@contributor  Paul \"Joey\" Clark (https://github.com/joeytwiddle)\n" +
+"@license      " + manifest["licenses"][0].type + "; " + manifest["licenses"][0].url + "\n" +
+"@version      " + manifest["version"] + "\n" +
+"@homepageURL  https://github.com/xthexder/wide-github\n" +
+"@supportURL   https://github.com/xthexder/wide-github/issues\n" +
+"==/UserStyle== */\n" +
+"\n" +
+"@-moz-document regexp(\"^https://(?:gist\\\\.)?github\\\\.com/.*\") {\n" +
+"\n";
+
+var footer = "" +
+"}\n"
+
+var styleSheet = fs.readFileSync('wide-github.css');
+var lines = styleSheet.toString().split("\n");
+
+var output = header;
+for (var i = 0; i < lines.length; i++) {
+	if (lines[i] !== "") {
+		output += "  " + lines[i]; // Indent
+	}
+	output += "\n";
+}
+output += footer;
+
+fs.writeFileSync("wide-github.user.css", output);

--- a/makejs.js
+++ b/makejs.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var fs = require('fs');
 
 var manifest = JSON.parse(fs.readFileSync('manifest.json'));
@@ -6,7 +8,7 @@ var header = "" +
 "\"use strict\";\n" +
 "\n" +
 "// ==UserScript==\n" +
-"// @name        Wide Github\n" +
+"// @name        " + manifest["name"] + "\n" +
 "// @namespace   https://github.com/xthexder/wide-github\n" +
 "// @description " + manifest["description"] + "\n" +
 "// @author      xthexder\n" +
@@ -14,7 +16,7 @@ var header = "" +
 "// @contributor Jason Frey (https://github.com/Fryguy)\n" +
 "// @contributor Marti Martz (https://github.com/Martii)\n" +
 "// @contributor Paul \"Joey\" Clark (https://github.com/joeytwiddle)\n" +
-"// @license     MIT; https://raw.githubusercontent.com/xthexder/wide-github/master/LICENSE\n" +
+"// @license     " + manifest["licenses"][0].type + "; " + manifest["licenses"][0].url + "\n" +
 "// @version     " + manifest["version"] + "\n" +
 "// @icon        https://raw.githubusercontent.com/xthexder/wide-github/master/icon.png\n" +
 "// @homepageURL https://github.com/xthexder/wide-github\n" +


### PR DESCRIPTION
* Utilize more of the manifest.json as the source point for .user.js
* Utilize more of the manifest.json as the source point for .user.css . See our sister site at https://openusercss.org if you care to publish but not a requirement.
* Currently `@moz-document` is Mozilla prefixed however CSS4 may pick this up as `@document` at a later date. Was supposed to be in CSS3 but delayed.

NOTES:
* Please let everyone know if you want to do ES6+ for the *node* side of this *(can be sped up/cleaned up some)*. .user.js would probably be best to keep ES5 for maximum browser compatibility with all engines if you wish
* Still needs `make css`, and whatever else you wish, run again to regenerate
* Not bumping version because output hasn't technically changed... only build system enhancements.
* Thanks for the consideration again

Indirectly applies to #15 but that's for Stylish *(proprietary installation method and distribution source locked)* not [Stylus](https://addons.mozilla.org/addon/styl-us/)