### PR TITLE
Compatibility fixes for use with Octotree (Fixes #31)

### DIFF
--- a/build/wide-github.user.css
+++ b/build/wide-github.user.css
@@ -7,6 +7,7 @@
 @contributor  Jason Frey (https://github.com/Fryguy)
 @contributor  Marti Martz (https://github.com/Martii)
 @contributor  Paul "Joey" Clark (https://github.com/joeytwiddle)
+@contributor  Collin Chaffin (https://github.com/CollinChaffin)
 @license      MIT; https://raw.githubusercontent.com/xthexder/wide-github/master/LICENSE
 @version      1.2.4
 @homepageURL  https://github.com/xthexder/wide-github
@@ -37,6 +38,14 @@
   .full-width .container {
     padding-left: 0px !important;
     padding-right: 0px !important;
+  }
+
+  /* CollinChaffin Fix for Octotree this also introduces unwanted horizontal scrollbars due to inline GH styles */
+  /* Also required is the change to loading in above directives and fix below for scrollbars */
+  .container-lg {
+    max-width: inherit !important;
+  /* CollinChaffin Fix for horizontal scrollbars with Octotree */
+    margin-left: 0px !important;
   }
 
   /* New PR split diff */

--- a/build/wide-github.user.js
+++ b/build/wide-github.user.js
@@ -9,12 +9,14 @@
 // @contributor Jason Frey (https://github.com/Fryguy)
 // @contributor Marti Martz (https://github.com/Martii)
 // @contributor Paul "Joey" Clark (https://github.com/joeytwiddle)
+// @contributor Collin Chaffin (https://github.com/CollinChaffin)
 // @license     MIT; https://raw.githubusercontent.com/xthexder/wide-github/master/LICENSE
 // @version     1.2.4
 // @icon        https://raw.githubusercontent.com/xthexder/wide-github/master/icon.png
 // @homepageURL https://github.com/xthexder/wide-github
 // @supportURL  https://github.com/xthexder/wide-github/issues
 // @include     *github.com*
+// @run-at      document-end
 // @grant       none
 // ==/UserScript==
 
@@ -41,6 +43,14 @@ var styleSheet = "" +
 ".full-width .container {" +
   "padding-left: 0px !important;" +
   "padding-right: 0px !important;" +
+"}" +
+
+// CollinChaffin Fix for Octotree this also introduces unwanted horizontal scrollbars due to inline GH styles
+// Also required is the change to loading in above directives and fix below for scrollbars
+".container-lg {" +
+  "max-width: inherit !important;" +
+// CollinChaffin Fix for horizontal scrollbars with Octotree
+  "margin-left: 0px !important;" +
 "}" +
 
 // New PR split diff

--- a/makecss.js
+++ b/makecss.js
@@ -14,6 +14,7 @@ var header = "" +
 "@contributor  Jason Frey (https://github.com/Fryguy)\n" +
 "@contributor  Marti Martz (https://github.com/Martii)\n" +
 "@contributor  Paul \"Joey\" Clark (https://github.com/joeytwiddle)\n" +
+"@contributor  Collin Chaffin (https://github.com/CollinChaffin)\n" +
 "@license      " + manifest["licenses"][0].type + "; " + manifest["licenses"][0].url + "\n" +
 "@version      " + manifest["version"] + "\n" +
 "@homepageURL  https://github.com/xthexder/wide-github\n" +

--- a/makejs.js
+++ b/makejs.js
@@ -16,16 +16,18 @@ var header = "" +
 "// @contributor Jason Frey (https://github.com/Fryguy)\n" +
 "// @contributor Marti Martz (https://github.com/Martii)\n" +
 "// @contributor Paul \"Joey\" Clark (https://github.com/joeytwiddle)\n" +
+"// @contributor Collin Chaffin (https://github.com/CollinChaffin)\n" +
 "// @license     " + manifest["licenses"][0].type + "; " + manifest["licenses"][0].url + "\n" +
 "// @version     " + manifest["version"] + "\n" +
 "// @icon        https://raw.githubusercontent.com/xthexder/wide-github/master/icon.png\n" +
 "// @homepageURL https://github.com/xthexder/wide-github\n" +
 "// @supportURL  https://github.com/xthexder/wide-github/issues\n" +
 "// @include     *github.com*\n" +
+"// @run-at      document-end\n" +
 "// @grant       none\n" +
 "// ==/UserScript==\n" +
 "\n" +
-"var styleSheet = \"\" +\n" +
+"var styleSheet = \"\" +\n" + 
 "";
 
 var footer = "" +

--- a/wide-github.css
+++ b/wide-github.css
@@ -22,6 +22,14 @@ header .container-lg {
   padding-right: 0px !important;
 }
 
+/* CollinChaffin Fix for Octotree this also introduces unwanted horizontal scrollbars due to inline GH styles */
+/* Also required is the change to loading in above directives and fix below for scrollbars */
+.container-lg {
+  max-width: inherit !important;
+/* CollinChaffin Fix for horizontal scrollbars with Octotree */
+  margin-left: 0px !important;
+}
+
 /* New PR split diff */
 .full-width .new-pr-form {
   max-width: none !important;


### PR DESCRIPTION
05-19-2019 - @CollinChaffin
1. Fixes issue #31
2. Fixes unwanted/unneeded horizontal scrollbar due to inline GH style
3. Changes loading order of userscript for Tampermonkey on Chrome to allow pinned expansion of Octotree bar to always occur before GH wide makes adjustments to elements

COMMENT/NOTE -- I am not aware of whether there is an equivalent preprocessor directive for the user.css to control the injection/load order (start/idle/end) (a quick search leads me to believe answer is no) that Tampermonkey/Userscript standard does.  Please be aware that of the three categories of changes in this PR, the user.css only has two and is missing the change to injection.  I also did not attempt to rebuild at ALL for the Chrome Extension as that probably needs a bit more testing to determine whether this fix is even needed.