### PR TITLE
Fix full width of discussion-timeline

### DIFF
--- a/wide-github.css
+++ b/wide-github.css
@@ -21,12 +21,7 @@ body:not(.wgh-disabled) .pr-toolbar {
 
 /* Repository Issues */
 body:not(.wgh-disabled) #js-repo-pjax-container .repository-content .discussion-timeline {  /* Issue body */
-  margin-left: -220px;
-  padding-left: 220px;
   width: 100% !important;
-}
-body:not(.wgh-disabled) #js-repo-pjax-container .repository-content .discussion-timeline::before { /* The vertical line running through the commit list on PRs and issues */
-  margin-left: 220px;
 }
 body:not(.wgh-disabled) .repository-content .timeline-new-comment { /* New Issue / issue comment form */
   max-width: 100% !important;


### PR DESCRIPTION
<img width="1346" alt="Screen Shot 2019-07-26 at 5 28 45 AM" src="https://user-images.githubusercontent.com/1457327/61941920-66ef6200-af66-11e9-9b7b-b4b35e219d5e.png">
