### PR TITLE
Fix GitHub spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-Wide Github
+Wide GitHub
 ===========
 
-This plugin changes all github repository pages to be full width and dynamically sized. Gists are supported as of version 1.1.0.
+This plugin changes all GitHub repository pages to be full width and dynamically sized. Gists are supported as of version 1.1.0.
 
 This repository always contains the latest version, the Chrome Store may not have been updated as recently.
 

--- a/build/wide-github.user.css
+++ b/build/wide-github.user.css
@@ -1,7 +1,7 @@
 /* ==UserStyle==
-@name         Wide Github
+@name         Wide GitHub
 @namespace    https://github.com/xthexder/wide-github
-@description  Change all Github repository and gist pages to be full width and dynamically sized.
+@description  Change all GitHub repository and gist pages to be full width and dynamically sized.
 @author       xthexder
 @copyright    2013+, xthexder (https://github.com/xthexder)
 @contributor  Jason Frey (https://github.com/Fryguy)

--- a/build/wide-github.user.js
+++ b/build/wide-github.user.js
@@ -1,9 +1,9 @@
 "use strict";
 
 // ==UserScript==
-// @name        Wide Github
+// @name        Wide GitHub
 // @namespace   https://github.com/xthexder/wide-github
-// @description Change all Github repository and gist pages to be full width and dynamically sized.
+// @description Change all GitHub repository and gist pages to be full width and dynamically sized.
 // @author      xthexder
 // @copyright   2013+, xthexder (https://github.com/xthexder)
 // @contributor Jason Frey (https://github.com/Fryguy)

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 2,
 
-  "name": "Wide Github",
-  "description": "Change all Github repository and gist pages to be full width and dynamically sized.",
+  "name": "Wide GitHub",
+  "description": "Change all GitHub repository and gist pages to be full width and dynamically sized.",
   "version": "1.4.3",
   "icons": {
     "32": "icon32.png",
@@ -12,7 +12,7 @@
 
   "browser_action": {
     "default_icon": "icon.png",
-    "default_title": "Toggle Wide Github"
+    "default_title": "Toggle Wide GitHub"
   },
   "content_scripts": [
     {


### PR DESCRIPTION
Small PR with a minor capitalization fix: `Github` -> `GitHub`