### PR TITLE
Add full height gist creation

### DIFF
--- a/build/wide-github.user.css
+++ b/build/wide-github.user.css
@@ -66,18 +66,10 @@
     width: 100% !important;
   }
 
-  /* Gists */
-  body:not(.wgh-disabled) .gist-content-wrapper .container {
-    width: auto !important;
-    margin-left: 20px !important;
-    margin-right: 20px !important;
-    min-width: 980px;
-  }
-  body:not(.wgh-disabled) .gist-content-wrapper .container-lg {
-    max-width: none !important;
-  }
-  body:not(.wgh-disabled) .gist-content-wrapper .container-lg .h-card {
-    width: 253px !important;
+  /* New gist input field height */
+  body:not(.wgh-disabled) .gist-content .commit-create .CodeMirror {
+    min-height: 250px;
+    height: calc(100vh - 500px) !important;
   }
 
   /* Refined GitHub extension conflict fix */

--- a/build/wide-github.user.js
+++ b/build/wide-github.user.js
@@ -70,18 +70,10 @@ var styleSheet = "" +
   "width: 100% !important;" +
 "}" +
 
-// Gists
-"body:not(.wgh-disabled) .gist-content-wrapper .container {" +
-  "width: auto !important;" +
-  "margin-left: 20px !important;" +
-  "margin-right: 20px !important;" +
-  "min-width: 980px;" +
-"}" +
-"body:not(.wgh-disabled) .gist-content-wrapper .container-lg {" +
-  "max-width: none !important;" +
-"}" +
-"body:not(.wgh-disabled) .gist-content-wrapper .container-lg .h-card {" +
-  "width: 253px !important;" +
+// New gist input field height
+"body:not(.wgh-disabled) .gist-content .commit-create .CodeMirror {" +
+  "min-height: 250px;" +
+  "height: calc(100vh - 500px) !important;" +
 "}" +
 
 // Refined GitHub extension conflict fix

--- a/wide-github.css
+++ b/wide-github.css
@@ -47,18 +47,10 @@ body:not(.wgh-disabled) .repository-content .capped-card-content { /* Graph card
   width: 100% !important;
 }
 
-/* Gists */
-body:not(.wgh-disabled) .gist-content-wrapper .container {
-  width: auto !important;
-  margin-left: 20px !important;
-  margin-right: 20px !important;
-  min-width: 980px;
-}
-body:not(.wgh-disabled) .gist-content-wrapper .container-lg {
-  max-width: none !important;
-}
-body:not(.wgh-disabled) .gist-content-wrapper .container-lg .h-card {
-  width: 253px !important;
+/* New gist input field height */
+body:not(.wgh-disabled) .gist-content .commit-create .CodeMirror {
+  min-height: 250px;
+  height: calc(100vh - 500px) !important;
 }
 
 /* Refined GitHub extension conflict fix */


### PR DESCRIPTION
A possible solution to Issue https://github.com/xthexder/wide-github/issues/67

I'll want to test this on a few more browsers / machines before I merge it, since I don't want extra scrollbars appearing if the height is off.

@jpluimers Give this change a try and see if it's to your liking

![image](https://user-images.githubusercontent.com/1594638/179070040-4227d845-5831-4f73-8d3f-eeb602f8ebbb.png)
