### PR TITLE
Update wide-github.user.js

### DIFF
--- a/build/wide-github.user.js
+++ b/build/wide-github.user.js
@@ -16,7 +16,7 @@
 // @icon        https://raw.githubusercontent.com/xthexder/wide-github/master/icons/icon.png
 // @homepageURL https://github.com/xthexder/wide-github
 // @supportURL  https://github.com/xthexder/wide-github/issues
-// @include     *github.com*
+// @match      *://github.com/*
 // @grant       none
 // ==/UserScript==
 


### PR DESCRIPTION
Using @include is potentially unsafe, and may be obsolete in early 2023. Switching to @match should prevent any issues.