### PR TITLE
Add @downloadURL

### DIFF
--- a/build/wide-github.user.js
+++ b/build/wide-github.user.js
@@ -16,6 +16,7 @@
 // @icon        https://raw.githubusercontent.com/xthexder/wide-github/master/icons/icon.png
 // @homepageURL https://github.com/xthexder/wide-github
 // @supportURL  https://github.com/xthexder/wide-github/issues
+// @downloadURL https://raw.githubusercontent.com/xthexder/wide-github/master/build/wide-github.user.js
 // @match       https://github.com/*
 // @match       https://gist.github.com/*
 // @grant       none

--- a/makejs.js
+++ b/makejs.js
@@ -23,6 +23,7 @@ var header = "" +
 "// @icon        https://raw.githubusercontent.com/xthexder/wide-github/master/icons/icon.png\n" +
 "// @homepageURL https://github.com/xthexder/wide-github\n" +
 "// @supportURL  https://github.com/xthexder/wide-github/issues\n" +
+"// @downloadURL https://raw.githubusercontent.com/xthexder/wide-github/master/build/wide-github.user.js\n" +
 "// @match       https://github.com/*\n" +
 "// @match       https://gist.github.com/*\n" +
 "// @grant       none\n" +


### PR DESCRIPTION
To support automatic (prompted) updates in Tampermonkey.

See https://www.tampermonkey.net/documentation.php?locale=en#meta:downloadURL

Without `@updateURL` also provided with the same value, Tampermonkey's editor's eslint shows a warning on the `@downloadURL` line: `Didn't find attribute 'updateURL' in the metadata`. I think it looks cleaner to specify it just once, so that's what I use in [all my userscripts](https://github.com/ZimbiX/userscripts) and ignore the warning